### PR TITLE
Improve StickyRecyclerHeadersTouchListener performance

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ LinearLayoutManager in either vertical or horizontal orientation.
 Download
 --------
 
-    compile 'com.timehop.stickyheadersrecyclerview:library:0.3.6@aar'
+    compile 'com.timehop.stickyheadersrecyclerview:library:0.4.2@aar'
 
 Usage
 -----
@@ -28,7 +28,8 @@ mRecyclerView.setLayoutManager(new LinearLayoutManager(context));
 mRecyclerView.addItemDecoration(new StickyRecyclerHeadersDecoration(mAdapter));
 ```
 
-If you are interested in listening for clicks, `StickyRecyclerHeadersTouchListener` allows you to listen for clicks on header views: create an instance of `StickyRecyclerHeadersTouchListener`, set the `OnHeaderClickListener`,
+`StickyRecyclerHeadersTouchListener` allows you to listen for clicks on header views.
+Simply create an instance of `StickyRecyclerHeadersTouchListener`, set the `OnHeaderClickListener`,
 and add the `StickyRecyclerHeadersTouchListener` as a touch listener to your `RecyclerView`.
 
 ```java
@@ -45,12 +46,54 @@ touchListener.setOnHeaderClickListener(
 mRecyclerView.addOnItemTouchListener(touchListener);
 ```
 
+=======
+The StickyHeaders aren't aware of your adapter so if you must notify them when your data set changes.
+
+```java
+    mAdapter.registerAdapterDataObserver(new RecyclerView.AdapterDataObserver() {
+      @Override public void onChanged() {
+        headersDecor.invalidateHeaders();
+      }
+    });
+```
+
+Item animators don't play nicely with RecyclerView decorations, so your mileage with that may vary.
+
+Compatibility
+-------------
+
+This should work in API 14+.
+
+>>>>>>> 8da3abdd108130930c31537d9537cf503fc022aa
 Known Issues
 ------------
 
 * Header views aren't recycled at this time
 * ItemAnimators issues
 
+* The header views are drawn to a canvas, and are not actually a part of the view hierarchy. As such, they can't have touch states, and you may run into issues if you try to load images into them asynchronously.
+
 Version History
 ---------------
+0.4.2 (8/21/2015) - Add support for reverse `ReverseLayout` in `LinearLayoutManager` by [AntonPukhonin](https://github.com/AntonPukhonin)
+
+0.4.1 (6/24/2015) - Fix "dancing headers" by DarkJaguar91
+
+0.4.0 (4/16/2015) - Code reorganization by danoz73, fixes for different sized headers, performance improvements
+
 0.3.6 (1/30/2015) - Prevent header clicks from passing on the touch event
+<<<<<<< HEAD
+=======
+
+0.3.5 (12/12/2014) - Add StickyRecyclerHeadersDecoration.invalidateHeaders() method
+
+0.3.4 (12/3/2014) - Fix issues with rendering of header views with header ID = 0
+
+0.3.3 (11/13/2014) - Fixes for padding, support views without headers
+
+0.3.2 (11/1/2014) - Bug fixes for list items with margins and deleting items
+
+0.2 (10/3/2014) - Add StickyRecyclerHeadersTouchListener
+
+0.1 (10/2/2014) - Initial Release
+>>>>>>> 8da3abdd108130930c31537d9537cf503fc022aa

--- a/build.gradle
+++ b/build.gradle
@@ -5,7 +5,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:1.0.0'
+        classpath 'com.android.tools.build:gradle:1.1.0'
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files
@@ -19,10 +19,10 @@ allprojects {
 }
 
 ext {
-    compileSdkVersion = 21
-    buildToolsVersion = '21.1.1'
-    targetSdkVersion = 21
+    compileSdkVersion = 22
+    buildToolsVersion = '22.0.1'
+    targetSdkVersion = 22
     minSdkVersion = 14
-    versionCode = 9
-    versionName = "0.3.6"
+    versionCode = 12
+    versionName = "0.4.2"
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -17,8 +17,8 @@
 # http://www.gradle.org/docs/current/userguide/multi_project_builds.html#sec:decoupled_projects
 # org.gradle.parallel=true
 
-VERSION_NAME=0.3.6
-VERSION_CODE=9
+VERSION_NAME=0.4.2
+VERSION_CODE=12
 GROUP=com.timehop.stickyheadersrecyclerview
 
 POM_DESCRIPTION=RecyclerView decorator for sticky list headers.

--- a/library/build.gradle
+++ b/library/build.gradle
@@ -17,7 +17,7 @@ android {
 }
 
 dependencies {
-    compile 'com.android.support:recyclerview-v7:21.0.0'
+    compile 'com.android.support:recyclerview-v7:22.2.0'
 }
 
 apply from: 'gradle-maven-push.gradle'

--- a/library/src/main/AndroidManifest.xml
+++ b/library/src/main/AndroidManifest.xml
@@ -1,5 +1,5 @@
-<manifest xmlns:android="http://schemas.android.com/apk/res/android"
-          xmlns:tools="http://schemas.android.com/tools"
-    package="com.timehop.stickyheadersrecyclerview" >
-    <application />
+<manifest
+    package="com.timehop.stickyheadersrecyclerview">
+
+    <application/>
 </manifest>

--- a/library/src/main/java/com/timehop/stickyheadersrecyclerview/HeaderPositionCalculator.java
+++ b/library/src/main/java/com/timehop/stickyheadersrecyclerview/HeaderPositionCalculator.java
@@ -4,6 +4,7 @@ import android.graphics.Rect;
 import android.support.v7.widget.LinearLayoutManager;
 import android.support.v7.widget.RecyclerView;
 import android.view.View;
+import android.widget.LinearLayout;
 
 import com.timehop.stickyheadersrecyclerview.caching.HeaderProvider;
 import com.timehop.stickyheadersrecyclerview.calculation.DimensionCalculator;
@@ -19,10 +20,8 @@ public class HeaderPositionCalculator {
   private final HeaderProvider mHeaderProvider;
   private final DimensionCalculator mDimensionCalculator;
 
-  public HeaderPositionCalculator(StickyRecyclerHeadersAdapter adapter,
-                                  HeaderProvider headerProvider,
-                                  OrientationProvider orientationProvider,
-                                  DimensionCalculator dimensionCalculator) {
+  public HeaderPositionCalculator(StickyRecyclerHeadersAdapter adapter, HeaderProvider headerProvider,
+      OrientationProvider orientationProvider, DimensionCalculator dimensionCalculator) {
     mAdapter = adapter;
     mHeaderProvider = headerProvider;
     mOrientationProvider = orientationProvider;
@@ -30,36 +29,61 @@ public class HeaderPositionCalculator {
   }
 
   /**
+   * Determines if a view should have a sticky header.
+   * The view has a sticky header if:
+   * 1. It is the first element in the recycler view
+   * 2. It has a valid ID associated to its position
+   *
+   * @param itemView given by the RecyclerView
+   * @param orientation of the Recyclerview
+   * @param position of the list item in question
+   * @return True if the view should have a sticky header
+   */
+  public boolean hasStickyHeader(View itemView, int orientation, int position) {
+    int offset, margin;
+    if (orientation == LinearLayout.VERTICAL) {
+      offset = itemView.getTop();
+      margin = mDimensionCalculator.getMargins(itemView).top;
+    } else {
+      offset = itemView.getLeft();
+      margin = mDimensionCalculator.getMargins(itemView).left;
+    }
+
+    return offset <= margin && mAdapter.getHeaderId(position) >= 0;
+  }
+
+  /**
    * Determines if an item in the list should have a header that is different than the item in the
    * list that immediately precedes it. Items with no headers will always return false.
    *
    * @param position of the list item in questions
+   * @param isReverseLayout TRUE if layout manager has flag isReverseLayout
    * @return true if this item has a different header than the previous item in the list
    * @see {@link StickyRecyclerHeadersAdapter#getHeaderId(int)}
    */
-  public boolean hasNewHeader(int position) {
-    if (getFirstHeaderPosition() == position) {
-      return true;
-    }
-
-    if (mAdapter.getHeaderId(position) < 0 || indexOutOfBounds(position)) {
+  public boolean hasNewHeader(int position, boolean isReverseLayout) {
+    if (indexOutOfBounds(position)) {
       return false;
     }
 
-    return mAdapter.getHeaderId(position) != mAdapter.getHeaderId(position - 1);
+    long headerId = mAdapter.getHeaderId(position);
+
+    if (headerId < 0) {
+      return false;
+    }
+
+    long nextItemHeaderId = -1;
+    int nextItemPosition = position + (isReverseLayout? 1: -1);
+    if (!indexOutOfBounds(nextItemPosition)){
+      nextItemHeaderId = mAdapter.getHeaderId(nextItemPosition);
+    }
+    int firstItemPosition = isReverseLayout? mAdapter.getItemCount()-1 : 0;
+
+    return position == firstItemPosition || headerId != nextItemHeaderId;
   }
 
   private boolean indexOutOfBounds(int position) {
     return position < 0 || position >= mAdapter.getItemCount();
-  }
-
-  private int getFirstHeaderPosition() {
-    for (int i = 0; i < mAdapter.getItemCount(); i++) {
-      if (mAdapter.getHeaderId(i) >= 0) {
-        return i;
-      }
-    }
-    return -1;
   }
 
   public Rect getHeaderBounds(RecyclerView recyclerView, View header, View firstView, boolean firstHeader) {
@@ -68,7 +92,7 @@ public class HeaderPositionCalculator {
 
     if (firstHeader && isStickyHeaderBeingPushedOffscreen(recyclerView, header)) {
       View viewAfterNextHeader = getFirstViewUnobscuredByHeader(recyclerView, header);
-      int firstViewUnderHeaderPosition = recyclerView.getChildPosition(viewAfterNextHeader);
+      int firstViewUnderHeaderPosition = recyclerView.getChildAdapterPosition(viewAfterNextHeader);
       View secondHeader = mHeaderProvider.getHeader(recyclerView, firstViewUnderHeaderPosition);
       translateHeaderWithNextHeader(recyclerView, mOrientationProvider.getOrientation(recyclerView), bounds,
           header, viewAfterNextHeader, secondHeader);
@@ -98,9 +122,13 @@ public class HeaderPositionCalculator {
 
   private boolean isStickyHeaderBeingPushedOffscreen(RecyclerView recyclerView, View stickyHeader) {
     View viewAfterHeader = getFirstViewUnobscuredByHeader(recyclerView, stickyHeader);
-    int firstViewUnderHeaderPosition = recyclerView.getChildPosition(viewAfterHeader);
+    int firstViewUnderHeaderPosition = recyclerView.getChildAdapterPosition(viewAfterHeader);
+    if (firstViewUnderHeaderPosition == RecyclerView.NO_POSITION) {
+        return false;
+    }
 
-    if (firstViewUnderHeaderPosition > 0 && hasNewHeader(firstViewUnderHeaderPosition)) {
+    boolean isReverseLayout = mOrientationProvider.isReverseLayout(recyclerView);
+    if (firstViewUnderHeaderPosition > 0 && hasNewHeader(firstViewUnderHeaderPosition, isReverseLayout)) {
       View nextHeader = mHeaderProvider.getHeader(recyclerView, firstViewUnderHeaderPosition);
       Rect nextHeaderMargins = mDimensionCalculator.getMargins(nextHeader);
       Rect headerMargins = mDimensionCalculator.getMargins(stickyHeader);
@@ -112,7 +140,7 @@ public class HeaderPositionCalculator {
           return true;
         }
       } else {
-        int leftOfNextHeader = viewAfterHeader.getLeft() - nextHeaderMargins.right- nextHeader.getWidth() - nextHeaderMargins.left;
+        int leftOfNextHeader = viewAfterHeader.getLeft() - nextHeaderMargins.right - nextHeader.getWidth() - nextHeaderMargins.left;
         int rightOfThisHeader = recyclerView.getPaddingLeft() + stickyHeader.getRight() + headerMargins.left + headerMargins.right;
         if (leftOfNextHeader < rightOfThisHeader) {
           return true;
@@ -123,9 +151,8 @@ public class HeaderPositionCalculator {
     return false;
   }
 
-  private void translateHeaderWithNextHeader(RecyclerView recyclerView, int orientation,
-                                             Rect translation, View currentHeader,
-                                             View viewAfterNextHeader, View nextHeader) {
+  private void translateHeaderWithNextHeader(RecyclerView recyclerView, int orientation, Rect translation,
+      View currentHeader, View viewAfterNextHeader, View nextHeader) {
     Rect nextHeaderMargins = mDimensionCalculator.getMargins(nextHeader);
     Rect stickyHeaderMargins = mDimensionCalculator.getMargins(currentHeader);
     if (orientation == LinearLayoutManager.VERTICAL) {
@@ -150,9 +177,12 @@ public class HeaderPositionCalculator {
    * @return first item that is fully beneath a header
    */
   private View getFirstViewUnobscuredByHeader(RecyclerView parent, View firstHeader) {
-    for (int i = 0; i < parent.getChildCount(); i++) {
+    boolean isReverseLayout = mOrientationProvider.isReverseLayout(parent);
+    int step = isReverseLayout? -1 : 1;
+    int from = isReverseLayout? parent.getChildCount()-1 : 0;
+    for (int i = from; i >= 0 && i <= parent.getChildCount() - 1; i += step) {
       View child = parent.getChildAt(i);
-      if (!itemIsObscuredByHeader(child, firstHeader, mOrientationProvider.getOrientation(parent))) {
+      if (!itemIsObscuredByHeader(parent, child, firstHeader, mOrientationProvider.getOrientation(parent))) {
         return child;
       }
     }
@@ -162,14 +192,24 @@ public class HeaderPositionCalculator {
   /**
    * Determines if an item is obscured by a header
    *
+   *
+   * @param parent
    * @param item        to determine if obscured by header
    * @param header      that might be obscuring the item
    * @param orientation of the {@link RecyclerView}
    * @return true if the item view is obscured by the header view
    */
-  private boolean itemIsObscuredByHeader(View item, View header, int orientation) {
+  private boolean itemIsObscuredByHeader(RecyclerView parent, View item, View header, int orientation) {
     RecyclerView.LayoutParams layoutParams = (RecyclerView.LayoutParams) item.getLayoutParams();
     Rect headerMargins = mDimensionCalculator.getMargins(header);
+
+    int adapterPosition = parent.getChildAdapterPosition(item);
+    if (adapterPosition == RecyclerView.NO_POSITION || mHeaderProvider.getHeader(parent, adapterPosition) != header) {
+      // Resolves https://github.com/timehop/sticky-headers-recyclerview/issues/36
+      // Handles an edge case where a trailing header is smaller than the current sticky header.
+      return false;
+    }
+
     if (orientation == LinearLayoutManager.VERTICAL) {
       int itemTop = item.getTop() - layoutParams.topMargin;
       int headerBottom = header.getBottom() + headerMargins.bottom + headerMargins.top;
@@ -202,5 +242,4 @@ public class HeaderPositionCalculator {
       return 0;
     }
   }
-
 }

--- a/library/src/main/java/com/timehop/stickyheadersrecyclerview/StickyRecyclerHeadersAdapter.java
+++ b/library/src/main/java/com/timehop/stickyheadersrecyclerview/StickyRecyclerHeadersAdapter.java
@@ -8,6 +8,7 @@ public interface StickyRecyclerHeadersAdapter<VH extends RecyclerView.ViewHolder
    * Get the ID of the header associated with this item.  For example, if your headers group
    * items by their first letter, you could return the character representation of the first letter.
    * Return a value < 0 if the view should not have a header (like, a header view or footer view)
+   *
    * @param position
    * @return
    */
@@ -17,6 +18,7 @@ public interface StickyRecyclerHeadersAdapter<VH extends RecyclerView.ViewHolder
    * Creates a new ViewHolder for a header.  This works the same way onCreateViewHolder in
    * Recycler.Adapter, ViewHolders can be reused for different views.  This is usually a good place
    * to inflate the layout for the header.
+   *
    * @param parent
    * @return
    */
@@ -24,6 +26,7 @@ public interface StickyRecyclerHeadersAdapter<VH extends RecyclerView.ViewHolder
 
   /**
    * Binds an existing ViewHolder to the specified adapter position.
+   *
    * @param holder
    * @param position
    */

--- a/library/src/main/java/com/timehop/stickyheadersrecyclerview/StickyRecyclerHeadersTouchListener.java
+++ b/library/src/main/java/com/timehop/stickyheadersrecyclerview/StickyRecyclerHeadersTouchListener.java
@@ -13,7 +13,7 @@ public class StickyRecyclerHeadersTouchListener implements RecyclerView.OnItemTo
   private OnHeaderClickListener mOnHeaderClickListener;
 
   public interface OnHeaderClickListener {
-    public void onHeaderClick(View header, int position, long headerId);
+    void onHeaderClick(View header, int position, long headerId);
   }
 
   public StickyRecyclerHeadersTouchListener(final RecyclerView recyclerView,
@@ -45,6 +45,10 @@ public class StickyRecyclerHeadersTouchListener implements RecyclerView.OnItemTo
 
   @Override
   public void onTouchEvent(RecyclerView view, MotionEvent e) { /* do nothing? */ }
+
+  @Override public void onRequestDisallowInterceptTouchEvent(boolean disallowIntercept) {
+    // do nothing
+  }
 
   private class SingleTapDetector extends GestureDetector.SimpleOnGestureListener {
     @Override

--- a/library/src/main/java/com/timehop/stickyheadersrecyclerview/StickyRecyclerHeadersTouchListener.java
+++ b/library/src/main/java/com/timehop/stickyheadersrecyclerview/StickyRecyclerHeadersTouchListener.java
@@ -1,13 +1,14 @@
 package com.timehop.stickyheadersrecyclerview;
 
 import android.support.v7.widget.RecyclerView;
-import android.view.GestureDetector;
 import android.view.MotionEvent;
 import android.view.SoundEffectConstants;
 import android.view.View;
 
+import com.timehop.stickyheadersrecyclerview.gesture.TapDetector;
+
 public class StickyRecyclerHeadersTouchListener implements RecyclerView.OnItemTouchListener {
-  private final GestureDetector mTapDetector;
+  private final TapDetector mTapDetector;
   private final RecyclerView mRecyclerView;
   private final StickyRecyclerHeadersDecoration mDecor;
   private OnHeaderClickListener mOnHeaderClickListener;
@@ -18,7 +19,7 @@ public class StickyRecyclerHeadersTouchListener implements RecyclerView.OnItemTo
 
   public StickyRecyclerHeadersTouchListener(final RecyclerView recyclerView,
       final StickyRecyclerHeadersDecoration decor) {
-    mTapDetector = new GestureDetector(recyclerView.getContext(), new SingleTapDetector());
+    mTapDetector = new TapDetector(recyclerView.getContext(), new TapListener());
     mRecyclerView = recyclerView;
     mDecor = decor;
   }
@@ -50,9 +51,14 @@ public class StickyRecyclerHeadersTouchListener implements RecyclerView.OnItemTo
     // do nothing
   }
 
-  private class SingleTapDetector extends GestureDetector.SimpleOnGestureListener {
+  private class TapListener implements TapDetector.OnTapListener {
     @Override
-    public boolean onSingleTapUp(MotionEvent e) {
+    public boolean onDown(MotionEvent e) {
+      return false;
+    }
+
+    @Override
+    public boolean onTapUp(MotionEvent e) {
       int position = mDecor.findHeaderPositionUnder((int) e.getX(), (int) e.getY());
       if (position != -1) {
         View headerView = mDecor.getHeaderView(mRecyclerView, position);
@@ -63,11 +69,6 @@ public class StickyRecyclerHeadersTouchListener implements RecyclerView.OnItemTo
         return true;
       }
       return false;
-    }
-
-    @Override
-    public boolean onDoubleTap(MotionEvent e) {
-      return true;
     }
   }
 }

--- a/library/src/main/java/com/timehop/stickyheadersrecyclerview/caching/HeaderProvider.java
+++ b/library/src/main/java/com/timehop/stickyheadersrecyclerview/caching/HeaderProvider.java
@@ -10,8 +10,9 @@ public interface HeaderProvider {
 
   /**
    * Will provide a header view for a given position in the RecyclerView
+   *
    * @param recyclerView that will display the header
-   * @param position that will be headed by the header
+   * @param position     that will be headed by the header
    * @return a header view for the given position and list
    */
   public View getHeader(RecyclerView recyclerView, int position);

--- a/library/src/main/java/com/timehop/stickyheadersrecyclerview/caching/HeaderViewCache.java
+++ b/library/src/main/java/com/timehop/stickyheadersrecyclerview/caching/HeaderViewCache.java
@@ -19,7 +19,7 @@ public class HeaderViewCache implements HeaderProvider {
   private final OrientationProvider mOrientationProvider;
 
   public HeaderViewCache(StickyRecyclerHeadersAdapter adapter,
-                         OrientationProvider orientationProvider) {
+      OrientationProvider orientationProvider) {
     mAdapter = adapter;
     mOrientationProvider = orientationProvider;
   }

--- a/library/src/main/java/com/timehop/stickyheadersrecyclerview/calculation/DimensionCalculator.java
+++ b/library/src/main/java/com/timehop/stickyheadersrecyclerview/calculation/DimensionCalculator.java
@@ -13,6 +13,7 @@ public class DimensionCalculator {
 
   /**
    * Returns {@link Rect} representing margins for any view.
+   *
    * @param view for which to get margins
    * @return margins for the given view. All 0 if the view does not support margins
    */
@@ -29,9 +30,10 @@ public class DimensionCalculator {
 
   /**
    * Converts {@link MarginLayoutParams} into a representative {@link Rect}
+   *
    * @param marginLayoutParams margins to convert to a Rect
    * @return Rect representing margins, where {@link MarginLayoutParams#leftMargin} is equivalent to
-   *         {@link Rect#left}, etc.
+   * {@link Rect#left}, etc.
    */
   private Rect getMarginRect(MarginLayoutParams marginLayoutParams) {
     return new Rect(

--- a/library/src/main/java/com/timehop/stickyheadersrecyclerview/gesture/TapDetector.java
+++ b/library/src/main/java/com/timehop/stickyheadersrecyclerview/gesture/TapDetector.java
@@ -1,0 +1,150 @@
+package com.timehop.stickyheadersrecyclerview.gesture;
+
+import android.content.Context;
+import android.view.GestureDetector;
+import android.view.MotionEvent;
+import android.view.ViewConfiguration;
+
+/**
+ * Slimmed down version of {@link GestureDetector} for simple tap events.
+ */
+public class TapDetector {
+    public interface OnTapListener {
+
+        /**
+         * Notified when a tap occurs with the down {@link MotionEvent}
+         * that triggered it. This will be triggered immediately for
+         * every down event. All other events should be preceded by this.
+         * @param e The down motion event.
+         */
+        boolean onDown(MotionEvent e);
+
+        /**
+         * Notified when a tap occurs with the up {@link MotionEvent}
+         * that triggered it.
+         * @param e The up motion event that completed the first tap
+         * @return true if the event is consumed, else false
+         */
+        boolean onTapUp(MotionEvent e);
+    }
+
+    private int mTouchSlopSquare;
+
+    private final OnTapListener mListener;
+
+    private boolean mAlwaysInTapRegion;
+
+    private MotionEvent mCurrentDownEvent;
+    private MotionEvent mPreviousUpEvent;
+
+    private float mLastFocusX;
+    private float mLastFocusY;
+    private float mDownFocusX;
+    private float mDownFocusY;
+
+    public TapDetector(Context context, OnTapListener listener) {
+        mListener = listener;
+        init(context);
+    }
+
+    private void init(Context context) {
+        if (mListener == null) {
+            throw new NullPointerException("OnTapListener must not be null");
+        }
+
+        // Fallback to support pre-donuts releases
+        int touchSlop;
+        if (context == null) {
+            //noinspection deprecation
+            touchSlop = ViewConfiguration.getTouchSlop();
+        } else {
+            final ViewConfiguration configuration = ViewConfiguration.get(context);
+            touchSlop = configuration.getScaledTouchSlop();
+        }
+        mTouchSlopSquare = touchSlop * touchSlop;
+    }
+
+    /**
+     * Analyzes the given motion event and if applicable triggers the
+     * appropriate callbacks on the {@link OnTapListener} supplied.
+     *
+     * @param ev The current motion event.
+     * @return true if the {@link OnTapListener} consumed the event,
+     *              else false.
+     */
+    public boolean onTouchEvent(MotionEvent ev) {
+        final int action = ev.getAction();
+
+        final boolean pointerUp =
+                (action & MotionEvent.ACTION_MASK) == MotionEvent.ACTION_POINTER_UP;
+        final int skipIndex = pointerUp ? ev.getActionIndex() : -1;
+
+        // Determine focal point
+        float sumX = 0, sumY = 0;
+        final int count = ev.getPointerCount();
+        for (int i = 0; i < count; i++) {
+            if (skipIndex == i) continue;
+            sumX += ev.getX(i);
+            sumY += ev.getY(i);
+        }
+        final int div = pointerUp ? count - 1 : count;
+        final float focusX = sumX / div;
+        final float focusY = sumY / div;
+
+        boolean handled = false;
+
+        switch (action & MotionEvent.ACTION_MASK) {
+            case MotionEvent.ACTION_DOWN:
+                mDownFocusX = mLastFocusX = focusX;
+                mDownFocusY = mLastFocusY = focusY;
+                if (mCurrentDownEvent != null) {
+                    mCurrentDownEvent.recycle();
+                }
+                mCurrentDownEvent = MotionEvent.obtain(ev);
+                mAlwaysInTapRegion = true;
+
+                handled |= mListener.onDown(ev);
+                break;
+
+            case MotionEvent.ACTION_MOVE:
+                final float scrollX = mLastFocusX - focusX;
+                final float scrollY = mLastFocusY - focusY;
+                if (mAlwaysInTapRegion) {
+                    final int deltaX = (int) (focusX - mDownFocusX);
+                    final int deltaY = (int) (focusY - mDownFocusY);
+                    int distance = (deltaX * deltaX) + (deltaY * deltaY);
+                    if (distance > mTouchSlopSquare) {
+                        mLastFocusX = focusX;
+                        mLastFocusY = focusY;
+                        mAlwaysInTapRegion = false;
+                    }
+                } else if ((Math.abs(scrollX) >= 1) || (Math.abs(scrollY) >= 1)) {
+                    mLastFocusX = focusX;
+                    mLastFocusY = focusY;
+                }
+                break;
+
+            case MotionEvent.ACTION_UP:
+                MotionEvent currentUpEvent = MotionEvent.obtain(ev);
+                if (mAlwaysInTapRegion) {
+                    handled = mListener.onTapUp(ev);
+                }
+                if (mPreviousUpEvent != null) {
+                    mPreviousUpEvent.recycle();
+                }
+                // Hold the event we obtained above - listeners may have changed the original.
+                mPreviousUpEvent = currentUpEvent;
+                break;
+
+            case MotionEvent.ACTION_CANCEL:
+                cancel();
+                break;
+        }
+
+        return handled;
+    }
+
+    private void cancel() {
+        mAlwaysInTapRegion = false;
+    }
+}

--- a/library/src/main/java/com/timehop/stickyheadersrecyclerview/rendering/HeaderRenderer.java
+++ b/library/src/main/java/com/timehop/stickyheadersrecyclerview/rendering/HeaderRenderer.java
@@ -22,18 +22,19 @@ public class HeaderRenderer {
   }
 
   private HeaderRenderer(OrientationProvider orientationProvider,
-                         DimensionCalculator dimensionCalculator) {
+      DimensionCalculator dimensionCalculator) {
     mOrientationProvider = orientationProvider;
     mDimensionCalculator = dimensionCalculator;
   }
 
   /**
    * Draws a header to a canvas, offsetting by some x and y amount
+   *
    * @param recyclerView the parent recycler view for drawing the header into
-   * @param canvas the canvas on which to draw the header
-   * @param header the view to draw as the header
-   * @param offset a Rect used to define the x/y offset of the header. Specify x/y offset by setting
-   *               the {@link Rect#left} and {@link Rect#top} properties, respectively.
+   * @param canvas       the canvas on which to draw the header
+   * @param header       the view to draw as the header
+   * @param offset       a Rect used to define the x/y offset of the header. Specify x/y offset by setting
+   *                     the {@link Rect#left} and {@link Rect#top} properties, respectively.
    */
   public void drawHeader(RecyclerView recyclerView, Canvas canvas, View header, Rect offset) {
     canvas.save();
@@ -58,7 +59,7 @@ public class HeaderRenderer {
    * correctly smaller width and height respectively.
    *
    * @param recyclerView for which to provide a header
-   * @param header for clipping
+   * @param header       for clipping
    * @return a {@link Rect} for clipping a provided header to the padding of a recycler view
    */
   private Rect getClipRectForHeader(RecyclerView recyclerView, View header) {

--- a/library/src/main/java/com/timehop/stickyheadersrecyclerview/util/LinearLayoutOrientationProvider.java
+++ b/library/src/main/java/com/timehop/stickyheadersrecyclerview/util/LinearLayoutOrientationProvider.java
@@ -11,13 +11,21 @@ public class LinearLayoutOrientationProvider implements OrientationProvider {
   @Override
   public int getOrientation(RecyclerView recyclerView) {
     RecyclerView.LayoutManager layoutManager = recyclerView.getLayoutManager();
+    throwIfNotLinearLayoutManager(layoutManager);
+    return ((LinearLayoutManager) layoutManager).getOrientation();
+  }
 
-    if (layoutManager instanceof LinearLayoutManager) {
-      return ((LinearLayoutManager) layoutManager).getOrientation();
-    } else {
+  @Override
+  public boolean isReverseLayout(RecyclerView recyclerView) {
+    RecyclerView.LayoutManager layoutManager = recyclerView.getLayoutManager();
+    throwIfNotLinearLayoutManager(layoutManager);
+    return ((LinearLayoutManager) layoutManager).getReverseLayout();
+  }
+
+  private void throwIfNotLinearLayoutManager(RecyclerView.LayoutManager layoutManager){
+    if (!(layoutManager instanceof LinearLayoutManager)) {
       throw new IllegalStateException("StickyListHeadersDecoration can only be used with a " +
           "LinearLayoutManager.");
     }
   }
-
 }

--- a/library/src/main/java/com/timehop/stickyheadersrecyclerview/util/OrientationProvider.java
+++ b/library/src/main/java/com/timehop/stickyheadersrecyclerview/util/OrientationProvider.java
@@ -9,4 +9,5 @@ public interface OrientationProvider {
 
   public int getOrientation(RecyclerView recyclerView);
 
+  public boolean isReverseLayout(RecyclerView recyclerView);
 }

--- a/sample/build.gradle
+++ b/sample/build.gradle
@@ -18,6 +18,5 @@ android {
 }
 
 dependencies {
-    compile "com.android.support:recyclerview-v7:21.0.0"
     compile project(':library')
 }

--- a/sample/src/main/AndroidManifest.xml
+++ b/sample/src/main/AndroidManifest.xml
@@ -1,20 +1,20 @@
 <?xml version="1.0" encoding="utf-8"?>
-<manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:tools="http://schemas.android.com/tools"
-    package="com.timehop.stickyheadersrecyclerview.sample" >
+<manifest
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    package="com.timehop.stickyheadersrecyclerview.sample">
 
     <application
         android:allowBackup="true"
         android:icon="@drawable/ic_launcher"
         android:label="@string/app_name"
-        android:theme="@style/AppTheme" >
+        android:theme="@style/AppTheme">
         <activity
             android:name=".MainActivity"
             android:label="@string/app_name">
             <intent-filter>
-                <action android:name="android.intent.action.MAIN" />
+                <action android:name="android.intent.action.MAIN"/>
 
-                <category android:name="android.intent.category.LAUNCHER" />
+                <category android:name="android.intent.category.LAUNCHER"/>
             </intent-filter>
         </activity>
     </application>

--- a/sample/src/main/java/com/timehop/stickyheadersrecyclerview/sample/DividerDecoration.java
+++ b/sample/src/main/java/com/timehop/stickyheadersrecyclerview/sample/DividerDecoration.java
@@ -53,14 +53,15 @@ public class DividerDecoration extends RecyclerView.ItemDecoration {
   public void drawVertical(Canvas c, RecyclerView parent) {
     final int left = parent.getPaddingLeft();
     final int right = parent.getWidth() - parent.getPaddingRight();
-
+    final int recyclerViewTop = parent.getPaddingTop();
+    final int recyclerViewBottom = parent.getHeight() - parent.getPaddingBottom();
     final int childCount = parent.getChildCount();
     for (int i = 0; i < childCount; i++) {
       final View child = parent.getChildAt(i);
       final RecyclerView.LayoutParams params = (RecyclerView.LayoutParams) child
           .getLayoutParams();
-      final int top = child.getBottom() + params.bottomMargin;
-      final int bottom = top + mDivider.getIntrinsicHeight();
+      final int top = Math.max(recyclerViewTop, child.getBottom() + params.bottomMargin);
+      final int bottom = Math.min(recyclerViewBottom, top + mDivider.getIntrinsicHeight());
       mDivider.setBounds(left, top, right, bottom);
       mDivider.draw(c);
     }
@@ -69,14 +70,15 @@ public class DividerDecoration extends RecyclerView.ItemDecoration {
   public void drawHorizontal(Canvas c, RecyclerView parent) {
     final int top = parent.getPaddingTop();
     final int bottom = parent.getHeight() - parent.getPaddingBottom();
-
+    final int recyclerViewLeft = parent.getPaddingLeft();
+    final int recyclerViewRight = parent.getWidth() - parent.getPaddingRight();
     final int childCount = parent.getChildCount();
     for (int i = 0; i < childCount; i++) {
       final View child = parent.getChildAt(i);
       final RecyclerView.LayoutParams params = (RecyclerView.LayoutParams) child
           .getLayoutParams();
-      final int left = child.getRight() + params.rightMargin;
-      final int right = left + mDivider.getIntrinsicHeight();
+      final int left = Math.max(recyclerViewLeft, child.getRight() + params.rightMargin);
+      final int right = Math.min(recyclerViewRight, left + mDivider.getIntrinsicHeight());
       mDivider.setBounds(left, top, right, bottom);
       mDivider.draw(c);
     }

--- a/sample/src/main/java/com/timehop/stickyheadersrecyclerview/sample/RecyclerItemClickListener.java
+++ b/sample/src/main/java/com/timehop/stickyheadersrecyclerview/sample/RecyclerItemClickListener.java
@@ -10,7 +10,7 @@ public class RecyclerItemClickListener implements RecyclerView.OnItemTouchListen
   private OnItemClickListener mListener;
 
   public interface OnItemClickListener {
-    public void onItemClick(View view, int position);
+    void onItemClick(View view, int position);
   }
 
   GestureDetector mGestureDetector;
@@ -27,10 +27,14 @@ public class RecyclerItemClickListener implements RecyclerView.OnItemTouchListen
   @Override public boolean onInterceptTouchEvent(RecyclerView view, MotionEvent e) {
     View childView = view.findChildViewUnder(e.getX(), e.getY());
     if (childView != null && mListener != null && mGestureDetector.onTouchEvent(e)) {
-      mListener.onItemClick(childView, view.getChildPosition(childView));
+      mListener.onItemClick(childView, view.getChildAdapterPosition(childView));
     }
     return false;
   }
 
   @Override public void onTouchEvent(RecyclerView view, MotionEvent motionEvent) { }
+
+  @Override public void onRequestDisallowInterceptTouchEvent(boolean disallowIntercept) {
+    // do nothing
+  }
 }

--- a/sample/src/main/res/layout/activity_main.xml
+++ b/sample/src/main/res/layout/activity_main.xml
@@ -1,15 +1,39 @@
-<RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<RelativeLayout
+    xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
     tools:context=".MainActivity"
-    android:paddingTop="18dp"
-    >
+    android:paddingTop="18dp">
+
+    <LinearLayout
+        android:id="@+id/buttons_container"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:orientation="horizontal">
+
+        <Button
+            android:id="@+id/button_update"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_weight="1"
+            android:text="@string/button_update"/>
+
+        <ToggleButton
+            android:id="@+id/button_is_reverse"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_weight="1"
+            android:textOff="@string/button_reverse"
+            android:textOn="@string/button_reverse"/>
+
+    </LinearLayout>
 
     <android.support.v7.widget.RecyclerView
         android:id="@+id/recyclerview"
         android:layout_width="match_parent"
         android:layout_height="match_parent"
+        android:layout_below="@id/buttons_container"
         android:layout_margin="18dp"
         android:padding="16dp"
         android:background="#ffbef0ff"

--- a/sample/src/main/res/values/strings.xml
+++ b/sample/src/main/res/values/strings.xml
@@ -2,5 +2,7 @@
 <resources>
 
     <string name="app_name">StickyHeadersRecyclerView</string>
+    <string name="button_update">Start Update</string>
+    <string name="button_reverse">Is reverse</string>
 
 </resources>


### PR DESCRIPTION
I merged in upstream changes up to 0.4.2 since there were some API breaking changes past that. @danoz73, please take a look at the last commit in the series.

The current touch listener adds a lot of latency from using Android's GestureDetector. It was slow because of the double tap detection so I copied it out and slimmed it down. 

Before:

![send-to-slow](https://cloud.githubusercontent.com/assets/8353078/10872058/d0c3e2f4-80c7-11e5-9c66-9873c7fa78bc.gif)

After:

![send-to-fix](https://cloud.githubusercontent.com/assets/8353078/10872327/78aa0322-80cd-11e5-9984-a9db9afb7f50.gif)
